### PR TITLE
Improve Email::Valid validation

### DIFF
--- a/lib/Mail/Builder/TypeConstraints.pm
+++ b/lib/Mail/Builder/TypeConstraints.pm
@@ -88,10 +88,10 @@ subtype 'Mail::Builder::Type::EmailAddress'
             $params{'-'.$param} = $EMAILVALID{$param}
                 if defined $EMAILVALID{$param};
         }
-        Email::Valid->address(
+        lc $_ eq lc (Email::Valid->address(
             %params,
             -address => $_,
-        );
+        ) // '');
     }
     => message { "'$_' is not a valid e-mail address" };
 

--- a/t/03_address.t
+++ b/t/03_address.t
@@ -2,7 +2,7 @@
 
 # t/03_address.t - check module for address handling
 
-use Test::Most tests => 28 + 1;
+use Test::Most tests => 29 + 1;
 use Test::NoWarnings;
 
 use Mail::Builder;
@@ -41,6 +41,9 @@ is ($address4->email, 'test@test.com','Check email address');
 
 # Broken Address 1
 throws_ok { Mail::Builder::Address->new( email => 'messed.up.@-address.comx' ) } qr/is not a valid e-mail address/,'Exception ok';
+
+# Broken Address 2
+throws_ok { Mail::Builder::Address->new( email => 'valid+except @space.com' ) } qr/is not a valid e-mail address/,'Exception ok';
 
 # Local Address 1
 $Mail::Builder::TypeConstraints::EMAILVALID{fqdn} = 0;


### PR DESCRIPTION
Hi Maros! Thanks for maintaining this great module.

While looking at the code, I found a use of Email::Valid where its return value was treated as a boolean. This is unfortunately a very common false assumption.

For example, if you call `Email::Valid->address` with an address that has spaces, it will trim spaces and return the address back to you, given that there is no other issues. This will be "true" if treated as boolean, but the address is still invalid. See [Email::Valid#EXAMPLES](https://metacpan.org/pod/Email::Valid#EXAMPLES) for details.

I've tried to handle this case, and added a test case to make sure it fails properly.

Let me know if there's anything you want me to update.
Thanks!

[\#cpan-prc](http://cpan-prc.org/) 