### PR TITLE
Fix failing MIME encoding related tests

### DIFF
--- a/t/07_builder_integration.t
+++ b/t/07_builder_integration.t
@@ -7,6 +7,7 @@ use Test::NoWarnings;
 
 use Mail::Builder;
 use Email::Address;
+use utf8;
 
 my ($mime1,$mime2,$mime3);
 
@@ -159,10 +160,10 @@ lives_ok {
     isa_ok($mime3,'MIME::Entity');
     isa_ok($mime3->head,'MIME::Head');
 
-    is($mime3->head->get('To'),'=?UTF-8?B?bmljZSDDg8K8ZnQtOCBuw4PCpG3Dg8Kp?= <recipient2@test.com>'."\n",'To header encoding ok');
+    is($mime3->head->get('To'),'=?UTF-8?B?bmljZSDDvGZ0LTggbsOkbcOp?= <recipient2@test.com>'."\n",'To header encoding ok');
     is($mime3->head->get('Reply-To'),'"Test3" <recipient3@test.com>'."\n",'Reply header encoding ok');
     is($mime3->head->get('Bcc'),'"Test4" <recipient4@test.com>'."\n",'Bcc header encoding ok');
-    is($mime3->head->get('Cc'),'=?UTF-8?B?dmVyeSBsb25nIG5hbWUgdGhhdCBleGNlZWRzIHRoZSA3NSBjaGFyYWN0ZXIgbGk=?= =?UTF-8?B?bWl0IG9mIGFuIGVuY29kZWQgd29yZCDDg8K8ZnQtOCBuw4PCpG3Dg8Kp?= <recipient5@test.com>'."\n",'Cc header encoding ok');
+    like($mime3->head->get('Cc'),qr/^=\?UTF-8\?B\?dmVyeSBsb25nIG5hbWUgdGhhdCBleGNlZWRzIHRoZSA3NSBjaGFyYWN0ZXIg\?=\s*=\?UTF-8\?B\?bGltaXQgb2YgYW4gZW5jb2RlZCB3b3JkIMO8ZnQtOCBuw6Rtw6k=\?=\s*<recipient5\@test\.com>\s*$/,'Cc header encoding ok');
     is($mime3->head->get('Subject'),'Testmail'."\n",'Subject ok');
     is($mime3->head->get('From'),'"me" <from2@test.com>'."\n",'From ok');
     is($mime3->head->get('Sender'),'"me2" <from3@test.com>'."\n",'From ok');


### PR DESCRIPTION
Hi Maros! Thanks again for maintaining this great module. Here's another PR, this time for a failing test in `07_builder_integration.t`

## `TO` header:
This is the name: `nice üft-8 nämé`
And this is what we are expecting as MIME header: `=?UTF-8?B?bmljZSDDg8K8ZnQtOCBuw4PCpG3Dg8Kp?=`
Which is Base64 encoded UTF-8 encoded word `bmljZSDDg8K8ZnQtOCBuw4PCpG3Dg8Kp`
If we try to decode it, it comes as: `nice Ã¼ft-8 nÃ¤mÃ©`..
Which was happening because there was no `use utf8` at the test file. I added that and updated the case.

## `CC` header:
This was what was reported in [RT 118885](https://rt.cpan.org/Public/Bug/Display.html?id=118885), and I was able to produce the error:
```
got:
=?UTF-8?B?dmVyeSBsb25nIG5hbWUgdGhhdCBleGNlZWRzIHRoZSA3NSBjaGFyYWN0ZXIg?= =?UTF-8?B?bGltaXQgb2YgYW4gZW5jb2RlZCB3b3JkIMODwrxmdC04IG7Dg8KkbcODwqk=?=

expected:
=?UTF-8?B?dmVyeSBsb25nIG5hbWUgdGhhdCBleGNlZWRzIHRoZSA3NSBjaGFyYWN0ZXIgbGk=?= =?UTF-8?B?bWl0IG9mIGFuIGVuY29kZWQgd29yZCDDg8K8ZnQtOCBuw4PCpG3Dg8Kp?=
```
After adding `use utf8;`, it became:
```
got
=?UTF-8?B?dmVyeSBsb25nIG5hbWUgdGhhdCBleGNlZWRzIHRoZSA3NSBjaGFyYWN0ZXIg?=
=?UTF-8?B?bGltaXQgb2YgYW4gZW5jb2RlZCB3b3JkIMO8ZnQtOCBuw6Rtw6k=?=
```
Which is two UTF-8 Base64 encoded words `dmVyeSBsb25nIG5hbWUgdGhhdCBleGNlZWRzIHRoZSA3NSBjaGFyYWN0ZXIgbGltaXQgb2YgYW4gZW5jb2RlZCB3b3JkIMO8ZnQtOCBuw6Rtw6k=`
And it actually decodes back to what we want: `very long name that exceeds the 75 character limit of an encoded word üft-8 nämé`. So I updated this test as well.

I also went ahead and replaced `is` with a `like`, giving a little more liberty to spaces we can have. [RFC2047](https://www.rfc-editor.org/rfc/pdfrfc/rfc2047.txt.pdf) (end of page 12) states that spaces between multiple encoded words are ignored, so this might be helpful if there is an update to `Encode` that adds/removes spaces.

Let me know if there's anything you want me to update.
Thanks!

[\#cpan-prc](http://cpan-prc.org/) 